### PR TITLE
Working clearing around pose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 find_package(ament_cmake REQUIRED)
 find_package(nav2_costmap_2d REQUIRED)
+find_package(nav2_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -56,6 +57,7 @@ endif()
 
 set(dependencies
   nav2_costmap_2d
+  nav2_msgs
   geometry_msgs
   pluginlib
   sensor_msgs
@@ -79,7 +81,7 @@ add_definitions(${EIGEN3_DEFINITIONS})
 set(srv_files "srv/SaveGrid.srv")
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces std_msgs
+  DEPENDENCIES builtin_interfaces std_msgs geometry_msgs
 )
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 

--- a/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
+++ b/include/spatio_temporal_voxel_layer/spatio_temporal_voxel_layer.hpp
@@ -67,6 +67,7 @@
 #include "sensor_msgs/msg/point_cloud2.hpp"
 #include "geometry_msgs/msg/point.hpp"
 #include "spatio_temporal_voxel_layer/srv/save_grid.hpp"
+#include "nav2_msgs/srv/clear_grid_around_pose.hpp"
 #include "std_srvs/srv/set_bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
 // projector
@@ -135,6 +136,12 @@ public:
     std::shared_ptr<spatio_temporal_voxel_layer::srv::SaveGrid::Request> req,
     std::shared_ptr<spatio_temporal_voxel_layer::srv::SaveGrid::Response> resp);
 
+  // Clearing grid around a pose
+  void ClearGridAroundPoseCallback(
+    const std::shared_ptr<rmw_request_id_t>/*header*/,
+    std::shared_ptr<nav2_msgs::srv::ClearGridAroundPose::Request> req,
+    std::shared_ptr<nav2_msgs::srv::ClearGridAroundPose::Response> resp);
+
   // Map saving service callbacks
   void SaveStvlMapCallback(
     const std::shared_ptr<rmw_request_id_t>/*header*/, 
@@ -179,6 +186,10 @@ private:
   rcl_interfaces::msg::SetParametersResult
     dynamicParametersCallback(std::vector<rclcpp::Parameter> parameters);
 
+  // Internal method for clearing the layer around a pose
+  void clearCostmapLayerAroundPose(
+    double pose_x, double pose_y, double reset_distance);
+
   laser_geometry::LaserProjection _laser_projector;
   std::vector<std::shared_ptr<message_filters::SubscriberBase<rclcpp_lifecycle::LifecycleNode>>>
     _observation_subscribers;
@@ -191,6 +202,7 @@ private:
   bool _publish_voxels, _mapping_mode, was_reset_, _autosaving_enabled, _should_load_navigation_data;
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr _voxel_pub;
   rclcpp::Service<spatio_temporal_voxel_layer::srv::SaveGrid>::SharedPtr _grid_saver;
+  rclcpp::Service<nav2_msgs::srv::ClearGridAroundPose>::SharedPtr _clear_grid_around_pose_srv;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr _save_stvl_map_srv;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr _erase_stvl_map_srv;
   std::unique_ptr<rclcpp::Duration> _map_save_duration;

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   
   <depend>builtin_interfaces</depend>
   <depend>nav2_costmap_2d</depend>
+  <depend>nav2_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>pluginlib</depend>
   <depend>sensor_msgs</depend>

--- a/src/spatio_temporal_voxel_layer.cpp
+++ b/src/spatio_temporal_voxel_layer.cpp
@@ -164,6 +164,11 @@ void SpatioTemporalVoxelLayer::onInitialize(void)
   _grid_saver = node->create_service<spatio_temporal_voxel_layer::srv::SaveGrid>(
     "save_grid", save_grid_callback, rmw_qos_profile_services_default, callback_group_);
 
+  auto clear_grid_around_pose_callback = std::bind(
+    &SpatioTemporalVoxelLayer::ClearGridAroundPoseCallback, this, _1, _2, _3);
+  _clear_grid_around_pose_srv = node->create_service<nav2_msgs::srv::ClearGridAroundPose>(
+    "clear_grid_around_pose", clear_grid_around_pose_callback, rmw_qos_profile_services_default, callback_group_);
+
   auto save_stvl_map_callback = std::bind(
     &SpatioTemporalVoxelLayer::SaveStvlMapCallback, this, _1, _2, _3);
   _save_stvl_map_srv = node->create_service<std_srvs::srv::Trigger>(
@@ -898,6 +903,27 @@ void SpatioTemporalVoxelLayer::SaveGridCallback(
 }
 
 /*****************************************************************************/
+void SpatioTemporalVoxelLayer::ClearGridAroundPoseCallback(
+  const std::shared_ptr<rmw_request_id_t>/*header*/,
+  std::shared_ptr<nav2_msgs::srv::ClearGridAroundPose::Request> req,
+  std::shared_ptr<nav2_msgs::srv::ClearGridAroundPose::Response> resp)
+/*****************************************************************************/
+{
+  boost::recursive_mutex::scoped_lock lock(_voxel_grid_lock);
+  try
+  {
+    clearCostmapLayerAroundPose(req->pose.pose.position.x, req->pose.pose.position.y, req->reset_distance);
+    resp->status = true;
+    return;
+  }
+  catch(const std::exception& e)
+  {
+    RCLCPP_WARN_STREAM(logger_, "SpatioTemporalVoxelLayer: Failed to remove grid around pose with exception: " << e.what());
+  }
+  resp->status = false;
+}
+
+/*****************************************************************************/
 void SpatioTemporalVoxelLayer::SaveStvlMapCallback(
   const std::shared_ptr<rmw_request_id_t>/*header*/,
   const std::shared_ptr<std_srvs::srv::Trigger::Request>,
@@ -1110,6 +1136,26 @@ void SpatioTemporalVoxelLayer::clearArea(
   boost::recursive_mutex::scoped_lock lock(_voxel_grid_lock);
   _voxel_grid->ResetGridArea(start_world, end_world, invert_area);
   CostmapLayer::clearArea(start_x, start_y, end_x, end_y, invert_area);
+}
+
+void SpatioTemporalVoxelLayer::clearCostmapLayerAroundPose(
+  double pose_x, double pose_y, double reset_distance)
+{
+  double start_point_x = pose_x - reset_distance / 2;
+  double start_point_y = pose_y - reset_distance / 2;
+  double end_point_x = start_point_x + reset_distance;
+  double end_point_y = start_point_y + reset_distance;
+
+  int start_x, start_y, end_x, end_y;
+  this->worldToMapEnforceBounds(start_point_x, start_point_y, start_x, start_y);
+  this->worldToMapEnforceBounds(end_point_x, end_point_y, end_x, end_y);
+
+  // Clear area is called with invert=true as it esnures only the area inside is cleared
+  clearArea(start_x, start_y, end_x, end_y, true);
+
+  double ox = this->getOriginX(), oy = this->getOriginY();
+  double width = this->getSizeInMetersX(), height = this->getSizeInMetersY();
+  this->addExtraBounds(ox, oy, ox + width, oy + height);
 }
 
 }  // namespace spatio_temporal_voxel_layer


### PR DESCRIPTION
Added clear_grid_around_pose service to stvl costmap layer (to clear the saved voxels around the destination)
base the clearing around existent clearArea function in stvl
